### PR TITLE
Fix error loading textris

### DIFF
--- a/aix_message_delivery.gemspec
+++ b/aix_message_delivery.gemspec
@@ -1,11 +1,12 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "aix_message_delivery/version"
+VERSION = '1.0.0'.freeze
+# FIXME: require "aix_message_delivery/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "aix_message_delivery"
-  spec.version       = AixMessageDelivery::VERSION
+  spec.version       = VERSION
   spec.authors       = ["yukihiro hara"]
   spec.email         = ["yukihr@gmail.com"]
 

--- a/aix_message_delivery.gemspec
+++ b/aix_message_delivery.gemspec
@@ -1,7 +1,7 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-VERSION = '1.0.0'.freeze
+VERSION = '1.0.1'.freeze
 # FIXME: require "aix_message_delivery/version"
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
Fixes #2 .
The problem was that we had `require 'textris'` in version.rb. 
Since AixMessageDelivery class inherits `Textris::Delivery::Base`, `require 'textris'` could not be deleted. So I defined `VERSION` in gemspec as a first aid.

