### PR TITLE
fix: form-urlencodedのContent-Typeを明示する

### DIFF
--- a/lib/aix_message.rb
+++ b/lib/aix_message.rb
@@ -49,7 +49,12 @@ class AixMessage
 
   def post_request(url, params)
     uri = URI.parse(url)
-    Net::HTTP.post(uri, URI.encode_www_form(params))
+    request = Net::HTTP::Post.new(uri)
+    request.set_form_data(params)
+
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
   end
 
   def base_params

--- a/lib/aix_message.rb
+++ b/lib/aix_message.rb
@@ -18,7 +18,7 @@ class AixMessage
   end
 
   def send!(phone, message)
-    res = post_request(ENDPOINT, sms_params("+#{phone}", message))
+    res = post_request(ENDPOINT, sms_params("+#{phone}", message), error_class: SMSDeliveryFailed)
 
     raise SMSDeliveryFailed, res.inspect unless res.is_a?(Net::HTTPOK)
 
@@ -31,7 +31,7 @@ class AixMessage
 
   def shorten_url!(url)
     params = base_params.merge(longUrl: url)
-    res = post_request(SHORTEN_URL_ENDPOINT, params)
+    res = post_request(SHORTEN_URL_ENDPOINT, params, error_class: URLShorteningFailed)
 
     raise URLShorteningFailed, res.inspect unless res.is_a?(Net::HTTPOK)
 
@@ -50,7 +50,7 @@ class AixMessage
 
   private
 
-  def post_request(url, params)
+  def post_request(url, params, error_class:)
     uri = URI.parse(url)
     request = Net::HTTP::Post.new(uri)
     request.set_form_data(params)
@@ -61,6 +61,8 @@ class AixMessage
       http.write_timeout = WRITE_TIMEOUT
       http.request(request)
     end
+  rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout => e
+    raise error_class, e.message
   end
 
   def base_params

--- a/lib/aix_message.rb
+++ b/lib/aix_message.rb
@@ -4,6 +4,9 @@ require 'net/http'
 class AixMessage
   ENDPOINT = "https://sms-api.aossms.com/p5/api/mt.json".freeze
   SHORTEN_URL_ENDPOINT = "https://sms-api.aossms.com/p1/api/shortenurl.json".freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 10
+  WRITE_TIMEOUT = 10
 
   class SMSDeliveryFailed < StandardError; end
   class URLShorteningFailed < StandardError; end
@@ -53,6 +56,9 @@ class AixMessage
     request.set_form_data(params)
 
     Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+      http.write_timeout = WRITE_TIMEOUT if http.respond_to?(:write_timeout=)
       http.request(request)
     end
   end

--- a/lib/aix_message.rb
+++ b/lib/aix_message.rb
@@ -58,7 +58,7 @@ class AixMessage
     Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.open_timeout = OPEN_TIMEOUT
       http.read_timeout = READ_TIMEOUT
-      http.write_timeout = WRITE_TIMEOUT if http.respond_to?(:write_timeout=)
+      http.write_timeout = WRITE_TIMEOUT
       http.request(request)
     end
   end

--- a/spec/aix_message_spec.rb
+++ b/spec/aix_message_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe AixMessage do
       allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout, "execution expired")
 
       expect { aix_message.send!(phone, message) }
-        .to raise_error(AixMessage::SMSDeliveryFailed, "execution expired")
+        .to raise_error(AixMessage::SMSDeliveryFailed, /execution expired/)
     end
   end
 

--- a/spec/aix_message_spec.rb
+++ b/spec/aix_message_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe AixMessage do
       expect(http).to have_received(:read_timeout=).with(10)
       expect(http).to have_received(:write_timeout=).with(10)
     end
+
+    it "raises SMSDeliveryFailed on timeout" do
+      allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout, "execution expired")
+
+      expect { aix_message.send!(phone, message) }
+        .to raise_error(AixMessage::SMSDeliveryFailed, "execution expired")
+    end
   end
 
   describe "#send!" do
@@ -80,6 +87,16 @@ RSpec.describe AixMessage do
       VCR.use_cassette("shortenurl_success") do
         expect(aix_message.shorten_url!(url)).to eq("https://ai9.jp/ohcO9a")
       end
+    end
+  end
+
+  describe "#shorten_url" do
+    let(:url) { "https://some.long-url.com/hoge/huga/piyo/asdfasdfasdfasdfasdf" }
+
+    it "falls back to original URL on timeout" do
+      allow(Net::HTTP).to receive(:start).and_raise(Net::OpenTimeout, "execution expired")
+
+      expect(aix_message.shorten_url(url)).to eq(url)
     end
   end
 end

--- a/spec/aix_message_spec.rb
+++ b/spec/aix_message_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe AixMessage do
       allow(http).to receive(:open_timeout=)
       allow(http).to receive(:read_timeout=)
       allow(http).to receive(:write_timeout=)
-      allow(http).to receive(:respond_to?).with(:write_timeout=).and_return(true)
       allow(http).to receive(:request) do |req|
         request = req
         response

--- a/spec/aix_message_spec.rb
+++ b/spec/aix_message_spec.rb
@@ -11,6 +11,38 @@ RSpec.describe AixMessage do
 
   describe "#send!" do
     let(:phone) { "818011112222" }
+    let(:message) { "hello" }
+
+    it "sends application/x-www-form-urlencoded" do
+      request = nil
+      response = instance_double(Net::HTTPOK, body: { responseCode: 0, responseMessage: "Success." }.to_json)
+      allow(response).to receive(:is_a?).with(Net::HTTPOK).and_return(true)
+
+      http = instance_double(Net::HTTP)
+      allow(http).to receive(:request) do |req|
+        request = req
+        response
+      end
+
+      allow(Net::HTTP).to receive(:start).and_yield(http)
+
+      aix_message.send!(phone, message)
+
+      expect(request["Content-Type"]).to eq("application/x-www-form-urlencoded")
+      expect(request.body).to eq(
+        URI.encode_www_form(
+          token: "XXXXXXXXXXXXXXXXXX",
+          clientId: "1234",
+          smsCode: "12345",
+          phoneNumber: "+#{phone}",
+          message: message
+        )
+      )
+    end
+  end
+
+  describe "#send!" do
+    let(:phone) { "818011112222" }
     let(:message) { <<~SMS_TEXT }
       親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。
       小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰を抜かす奴があるかと云ったから、この次は抜かさずに飛んで見せますと答えた。（青空文庫より）

--- a/spec/aix_message_spec.rb
+++ b/spec/aix_message_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe AixMessage do
       response = instance_double(Net::HTTPOK, body: { responseCode: 0, responseMessage: "Success." }.to_json)
       allow(response).to receive(:is_a?).with(Net::HTTPOK).and_return(true)
 
-      http = instance_double(Net::HTTP)
+      http = double("http")
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:write_timeout=)
+      allow(http).to receive(:respond_to?).with(:write_timeout=).and_return(true)
       allow(http).to receive(:request) do |req|
         request = req
         response
@@ -38,6 +42,9 @@ RSpec.describe AixMessage do
           message: message
         )
       )
+      expect(http).to have_received(:open_timeout=).with(5)
+      expect(http).to have_received(:read_timeout=).with(10)
+      expect(http).to have_received(:write_timeout=).with(10)
     end
   end
 


### PR DESCRIPTION
## 概要
- AIX API への POST で `Content-Type: application/x-www-form-urlencoded` を明示するように変更
- Ruby 3.4 系の `Net::HTTP.post(uri, URI.encode_www_form(params))` では `Content-Type` が付かず、415 Unsupported Media Type になるケースを防止
- request header と body を検証する spec を追加

## 変更内容
- `AixMessage#post_request` を `Net::HTTP::Post` + `set_form_data` に変更
- `spec/aix_message_spec.rb` に `Content-Type` と body の検証を追加

## 確認
- `ruby -c lib/aix_message.rb`
- `ruby -c spec/aix_message_spec.rb`
- Ruby 3.4.1 で `application/x-www-form-urlencoded` が付くことを手元スクリプトで確認

## 補足
- `bundle install` は `nokogiri 1.10.10` の native build が `arm64-darwin24` で失敗し、repo の rspec は完走していません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for outbound request formatting, authentication/recipient formatting, configurable connection timeouts, and timeout-driven behavior.

* **Refactor**
  * Switched to explicit HTTP request handling with configurable network timeouts and improved connection lifecycle.

* **Bug Fixes**
  * Improved timeout handling to raise consistent errors on send failures and to return original URLs when shortening fails due to timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->