### PR TITLE
fix: nokogiri の下限を引き上げる

### DIFF
--- a/aix_message_delivery.gemspec
+++ b/aix_message_delivery.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "textris", "~> 0.7.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "nokogiri", ">= 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", "~> 6.0"

--- a/aix_message_delivery.gemspec
+++ b/aix_message_delivery.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "textris", "~> 0.7.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "nokogiri", ">= 1.13"
+  spec.add_development_dependency "nokogiri", ">= 1.13", "< 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", "~> 6.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'logger'
 require 'aix_message_delivery'
 require 'webmock/rspec'
 require 'vcr'


### PR DESCRIPTION
概要: Ruby 3.0 CI で古い nokogiri が選ばれて build 失敗していたため、開発依存に nokogiri >= 1.13 を追加しました。既存 PR #10 からは切り離した独立差分です。確認: ruby -c aix_message_delivery.gemspec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended development tooling and test configuration: updated development dependencies and added logging support to the test environment. These changes affect build/test workflows only and do not alter runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->